### PR TITLE
Use node 10.10 on circle ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/node:9.6
+      - image: circleci/node:10.10
     working_directory: ~/repo
 
     steps:


### PR DESCRIPTION
Update node version from 9.6 to 10.10 on circle ci