### PR TITLE
Add pretty print feature to generate function

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,19 @@ Example of the result in the time of writing this.
   // => RF4714508655422864
 ```
 
+As creditor references are commonly displayed in groups of 4 characters
+you can use the optional `pretty` flag to format the returned value.
+
+```
+  import {generate} from 'node-iso11649'
+
+  console.log(generate({
+    reference: '12345 12345',
+    pretty: true
+  }))
+  // => RF45 1234 5123 45
+```
+
 ### Validating RF creditor reference
 
 Valid RF creditor reference characteristics:

--- a/dist/types.d.ts
+++ b/dist/types.d.ts
@@ -1,4 +1,10 @@
-declare const generate: (reference?: string) => string;
-declare const validate: (reference: string) => boolean;
+export interface GenerateOptions {
+  reference?: string;
+  pretty?: boolean;
+}
+
+declare function generate(reference?: string) => string;
+declare function generate(options: GenerateOptions) => string;
+declare function validate(reference: string) => boolean;
 
 export { generate, validate }

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -10,10 +10,39 @@ const calculateRFChecksum = (reference: string): string => {
 const generateRFreference = (reference: string): string =>
   `RF${calculateRFChecksum(reference)}${reference}`
 
-export default (reference?: string): string => {
+const prettyFormatRFreference = (reference: string): string =>
+  // place a space after each group that is not at the end of the string
+  reference.replace(/(.{4})(?!$)/g, '$1 ')
+
+interface GenerateOptions {
+  reference?: string
+  pretty?: boolean
+}
+
+function generate (reference?: string): string;
+function generate (options: GenerateOptions): string;
+function generate (options?: any): string {
+  let reference: string | undefined
+  let pretty: boolean = false
+
+  if (typeof options === 'string') {
+    reference = options
+  } else if (typeof options === 'object') {
+    reference = options.reference
+    pretty = options.pretty === true
+  } else {
+    reference = undefined
+  }
+
   const normalizedReference = typeof reference === 'undefined'
     ? generateFinnishReference()
     : normalizeReference(reference)
 
-  return generateRFreference(normalizedReference)
+  const rfReference = generateRFreference(normalizedReference)
+
+  return pretty
+    ? prettyFormatRFreference(rfReference)
+    : rfReference
 }
+
+export default generate

--- a/test/generate.spec.ts
+++ b/test/generate.spec.ts
@@ -32,3 +32,24 @@ test('should generate valid reference from timestamp', (assert: test.Test) => {
   assert.equal(actual, expected)
   assert.end()
 })
+
+test('should generate pretty reference with numbers', (assert: test.Test) => {
+  const expected = 'RF71 2348 231'
+  const actual = generate({
+    reference: '2348231',
+    pretty: true
+  })
+
+  assert.equal(actual, expected)
+  assert.end()
+})
+
+test('should generate pretty reference from timestamp', (assert: test.Test) => {
+  const expected = true
+  const actual = validate(generate({
+    pretty: true
+  }))
+
+  assert.equal(actual, expected)
+  assert.end()
+})


### PR DESCRIPTION
Hi @nruotsal, thanks for this library!

As it seems to be quite common to format RF creditor references in groups of 4 characters, this PR adds an option to the `generate` function which does this:

```
import {generate} from 'node-iso11649'

console.log(generate({
  reference: '12345 12345',
  pretty: true
}))
// => RF45 1234 5123 45
```

It does it by overloading the existing signature of `generate`, so that it can still be called with an optional string or - with this change - an object that could host additional options in the future.