### PR TITLE
Add parse function

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,27 @@ Valid RF creditor reference characteristics:
   // => false
 ```
 
+### Parsing RF creditor reference
+
+The reference part can be extracted from the RF creditor reference.
+This validates the entered RF creditor reference according to the
+'Validating RF creditor reference'. It returns the reference string
+if valid and null if invalid.
+
+```
+  import {parse} from 'node-iso11649'
+
+  console.log(parse('RF47 1450 8655 4228 64'))
+  // => 14508655422864
+```
+
+```
+  import {parse} from 'node-iso11649'
+
+  console.log(parse('RF00TEST'))
+  // => null
+```
+
 ## Tests
 
     npm run lint

--- a/dist/types.d.ts
+++ b/dist/types.d.ts
@@ -1,4 +1,5 @@
 declare const generate: (reference?: string) => string;
 declare const validate: (reference: string) => boolean;
+declare const parse: (reference: string) => string | null;
 
-export { generate, validate }
+export { generate, validate, parse }

--- a/src/common.ts
+++ b/src/common.ts
@@ -1,3 +1,5 @@
+const REFERENCE_FORMAT: RegExp = /^RF[0-9]{2}[0-9A-Z]+$/
+
 interface CharTable {
   [key: string]: number
 }
@@ -23,3 +25,19 @@ export const modulo97 = (dividend: string): number => {
     ? chunks.map(Number).reduce((prev: number, curr: number) => parseInt(`${prev}${curr}`) % 97, 0)
     : -1
 }
+
+export const moveRfToEnd = (reference: string): string[] =>
+  (reference.substr(4) + reference.substr(0, 4)).split('')
+
+export const isValidChecksum = (reference: string): boolean => {
+  const preResult = moveRfToEnd(reference).map(substituteCharWithNumber).join('')
+  return modulo97(preResult) === 1
+}
+
+export const isValidFormat = (reference: string): boolean =>
+  reference.match(REFERENCE_FORMAT) !== null
+
+export const isValid = (reference: string): boolean =>
+  reference.length <= 25 &&
+    isValidFormat(reference) &&
+    isValidChecksum(reference)

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import generate from './generate'
 import validate from './validate'
+import parse from './parse'
 
-export { generate, validate }
+export { generate, validate, parse }

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -1,0 +1,17 @@
+import { normalizeReference, isValid } from './common'
+
+function removeRf (reference: string): string {
+  return reference.substr(4)
+}
+
+function parse (reference: string): string | null {
+  const normalizedRef = normalizeReference(reference)
+
+  if (!isValid(normalizedRef)) {
+    return null
+  }
+
+  return removeRf(normalizedRef)
+}
+
+export default parse

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -1,21 +1,6 @@
-import { normalizeReference, modulo97, substituteCharWithNumber } from './common'
-
-const REFERENCE_FORMAT: RegExp = /^RF[0-9]{2}[0-9A-Z]+$/
-
-const moveRfToEnd = (reference: string): string[] =>
-  (reference.substr(4) + reference.substr(0, 4)).split('')
-
-const isValidChecksum = (reference: string): boolean => {
-  const preResult = moveRfToEnd(reference).map(substituteCharWithNumber).join('')
-  return modulo97(preResult) === 1
-}
-
-const isValidFormat = (reference: string): boolean =>
-  reference.match(REFERENCE_FORMAT) !== null
+import { normalizeReference, isValid } from './common'
 
 export default (reference: string): boolean => {
   const normalizedRef = normalizeReference(reference)
-  return normalizedRef.length <= 25 &&
-    isValidFormat(normalizedRef) &&
-    isValidChecksum(normalizedRef)
+  return isValid(normalizedRef)
 }

--- a/test/parse.spec.ts
+++ b/test/parse.spec.ts
@@ -1,0 +1,42 @@
+import * as test from 'tape'
+import { parse } from '../src/index'
+
+test('should parse reference with numbers', (assert: test.Test) => {
+  const expected = '2348236'
+  const actual = parse('RF33 2348 236')
+
+  assert.equal(actual, expected)
+  assert.end()
+})
+
+test('should parse reference with characters', (assert: test.Test) => {
+  const expected = 'AB2G59X56V543'
+  const actual = parse('RF19 AB2G 59X5 6V54 3')
+
+  assert.equal(actual, expected)
+  assert.end()
+})
+
+test('should parse invalid reference with exception', (assert: test.Test) => {
+  const expected = null
+  const actual = parse('RF09 2348 236')
+
+  assert.equal(actual, expected)
+  assert.end()
+})
+
+test('should parse 25 char long reference', (assert: test.Test) => {
+  const expected = '123456789012345678901'
+  const actual = parse('RF40 1234 5678 9012 3456 7890 1')
+
+  assert.equal(actual, expected)
+  assert.end()
+})
+
+test('should parse 26 char long reference with exception', (assert: test.Test) => {
+  const expected = null
+  const actual = parse('RF43 1234 5678 9012 3456 7890 12')
+
+  assert.equal(actual, expected)
+  assert.end()
+})


### PR DESCRIPTION
I'm encoding an internal reference into the RF creditor reference. It would be great if this library had a way to decode an internal reference again from the RF creditor reference. It seems to be the right place for such a feature, as this library already handles all the specifics of this standard.

This PR adds the `parse` function that does exactly that. Given a valid arbitrarily formatted RF creditor reference, it returns the reference. If the input is invalid, it returns null instead.

```
  import {parse} from 'node-iso11649'
   console.log(parse('RF47 1450 8655 4228 64'))
  // => 14508655422864
```

 ```
  import {parse} from 'node-iso11649'
   console.log(parse('RF00TEST'))
  // => null
```

As `parse` uses many functions used by `validate`, I've moved some of them to `common` and added a `isValid` function that checks for length, format and checksum in one call.