### PR TITLE
Fix types.d.ts

### DIFF
--- a/dist/types.d.ts
+++ b/dist/types.d.ts
@@ -3,9 +3,9 @@ export interface GenerateOptions {
   pretty?: boolean;
 }
 
-declare function generate(reference?: string) => string;
-declare function generate(options: GenerateOptions) => string;
-declare function validate(reference: string) => boolean;
-declare const parse: (reference: string) => string | null;
+declare function generate(reference?: string): string;
+declare function generate(options: GenerateOptions): string;
+declare function validate(reference: string): boolean;
+declare function parse(reference: string): string | null;
 
 export { generate, validate, parse }


### PR DESCRIPTION
Fixes the syntax errors in `types.d.ts` I introduced with #149 and #150. 😱 